### PR TITLE
Bugfix for css tags that don't have rules attrib.

### DIFF
--- a/main/src/contentScripts.js
+++ b/main/src/contentScripts.js
@@ -8,10 +8,10 @@ const contentScripts = (() => {
    *  or only a href if the stylesheet is external
    */
   function getStyleSheets() {
-    return [].slice.call(document.styleSheets).map(({ cssRules: cr, href }) => (
+    return [].slice.call(document.styleSheets).map((x) => (
       {
-        href,
-        cssText: (cr && cr.length) ? [].slice.call(cr).map(r => r.cssText).join(" \n") : null,
+        href: x.href,
+        cssText: (x.hasOwnProperty('rules') && x.cssRules && x.cssRules.length) ? [].slice.call(x.cssRules).map(r => r.cssText).join(" \n") : null,
       }
     )).filter(v => v.href || v.cssText);
   }


### PR DESCRIPTION
As per issue #6 , there was a stylesheet that didn't have this prop, so it was throwing an error.